### PR TITLE
feat: attach environment to initialization call

### DIFF
--- a/lib/src/network_service.dart
+++ b/lib/src/network_service.dart
@@ -1,11 +1,12 @@
 import 'dart:convert';
 
 import 'package:http/http.dart' as http;
+import 'package:meta/meta.dart';
+
 import 'statsig_event.dart';
 import 'statsig_metadata.dart';
 import 'statsig_options.dart';
 import 'statsig_user.dart';
-import 'package:meta/meta.dart';
 
 const defaultHost = 'https://statsigapi.net/v1';
 
@@ -40,7 +41,8 @@ class NetworkService {
     return await _post(
             url,
             {
-              "user": user.toPrivacySensitiveJson(),
+              "user": user.toPrivacySensitiveJson()
+                ..addAll(_options.environment?.toJson() ?? {}),
               "statsigMetadata": StatsigMetadata.toJson()
             },
             3,

--- a/lib/src/statsig_options.dart
+++ b/lib/src/statsig_options.dart
@@ -18,6 +18,6 @@ enum StatsigEnvironment {
 
 extension ToJson on StatsigEnvironment {
   Map<String, dynamic> toJson() => <String, dynamic>{
-      "statsigEnvironment": <String, String>{"tier": this.toString().replaceAll("StatsigEnvironment.", "")};
-  }
+      "statsigEnvironment": <String, String>{"tier": this.toString().replaceAll("StatsigEnvironment.", "")}
+  };
 }

--- a/lib/src/statsig_options.dart
+++ b/lib/src/statsig_options.dart
@@ -5,5 +5,33 @@ class StatsigOptions {
   /// How long (in seconds) the Statsig client waits for the initial network request. Defaults to 3 seconds
   int initTimeout;
 
-  StatsigOptions([this.api, this.initTimeout = 3]);
+  StatsigEnvironment? environment;
+
+  StatsigOptions({this.api, this.initTimeout = 3, this.environment});
+}
+
+enum StatsigEnvironment {
+  development,
+  staging,
+  production,
+}
+
+extension ToJson on StatsigEnvironment {
+  Map<String, dynamic> toJson() {
+    late final String environmentName;
+    switch (this) {
+      case StatsigEnvironment.development:
+        environmentName = 'development';
+        break;
+      case StatsigEnvironment.staging:
+        environmentName = 'staging';
+        break;
+      case StatsigEnvironment.production:
+        environmentName = 'production';
+        break;
+    }
+    return <String, dynamic>{
+      "statSigEnvironment": <String, String>{"tier": environmentName}
+    };
+  }
 }

--- a/lib/src/statsig_options.dart
+++ b/lib/src/statsig_options.dart
@@ -17,21 +17,7 @@ enum StatsigEnvironment {
 }
 
 extension ToJson on StatsigEnvironment {
-  Map<String, dynamic> toJson() {
-    late final String environmentName;
-    switch (this) {
-      case StatsigEnvironment.development:
-        environmentName = 'development';
-        break;
-      case StatsigEnvironment.staging:
-        environmentName = 'staging';
-        break;
-      case StatsigEnvironment.production:
-        environmentName = 'production';
-        break;
-    }
-    return <String, dynamic>{
-      "statSigEnvironment": <String, String>{"tier": environmentName}
-    };
+  Map<String, dynamic> toJson() => <String, dynamic>{
+      "statsigEnvironment": <String, String>{"tier": this.toString().replaceAll("StatsigEnvironment.", "")};
   }
 }

--- a/lib/statsig.dart
+++ b/lib/statsig.dart
@@ -1,4 +1,4 @@
-export 'src/statsig_options.dart' show StatsigOptions;
+export 'src/statsig_options.dart' show StatsigOptions, StatsigEnvironment;
 export 'src/statsig_user.dart' show StatsigUser;
 export 'src/dynamic_config.dart' show DynamicConfig;
 export 'src/statsig_layer.dart' show Layer;


### PR DESCRIPTION
This is a starting point to address https://github.com/statsig-io/dart-sdk/issues/3

More specifically, at the moment this uses the environment when fetching experiments and other remote values, but it does not attach the environment to logged events.