### PR TITLE
chore: update uuid to 4.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   crypto: ^3.0.1
   http: ^0.13.4
   meta: ^1.7.0
-  uuid: ^3.0.6
+  uuid: ^4.0.0
 
 dev_dependencies:
   lints: ^1.0.0


### PR DESCRIPTION
Updating `uuid` to 4.0.0. This will help with projects where the latest datadog package is also being used.