### PR TITLE
Upgrading http to 1.0.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.1
-  http: ^0.13.4
+  http: ^1.0.0
   meta: ^1.7.0
   uuid: ^4.0.0
 


### PR DESCRIPTION
http 1.0.0 has been out for 10 months and provides greater compatibility with other packages.